### PR TITLE
Feature/form redirect

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Register Scripts and Styles
+ * 
  * @package costaricaadventurers
  */
 
@@ -17,7 +18,7 @@ function register_scripts() {
     // Enqueue Parent Theme Stylesheet
     wp_enqueue_style(
         'adventor-parent',
-        get_theme_file_uri( '/style.css' ),
+        get_template_directory_uri() . '/style.css',
         [],
         filemtime( get_template_directory() . '/style.css' )
     );
@@ -37,34 +38,43 @@ function register_scripts() {
     $asset_file = get_stylesheet_directory() . '/build/index.asset.php';
     if ( file_exists( $asset_file ) ) {
         $asset = include $asset_file;
+
         wp_enqueue_script(
             'costa-rica-adventures-scripts',
             get_stylesheet_directory_uri() . '/build/index.js',
-            isset( $asset['dependencies'] ) ? $asset['dependencies'] : [],
-            isset( $asset['version'] ) ? $asset['version'] : false,
+            $asset['dependencies'] ?? [],
+            $asset['version'] ?? false,
             true
         );
+
+        // Localize configuration for Tours Cart integration
+        wp_localize_script(
+            'costa-rica-adventures-scripts',
+            'ToursCartCfg',
+            [
+                'storageKey'    => 'toursCart',
+                'editToursURL'  => $inquiry_page_id ? get_permalink( $inquiry_page_id ) : '',
+                'isInquiryPage' => (bool) ( $inquiry_page_id && is_page( $inquiry_page_id ) ),
+            ]
+        );
+
+        // WPML: Get correct contact page URL for current language
+        $default_contact_page = get_page_by_path( 'contact-us-at' );
+        $translated_contact_page_id = $default_contact_page
+            ? apply_filters( 'wpml_object_id', $default_contact_page->ID, 'page', true )
+            : null;
+
+        $redirect_url = $translated_contact_page_id
+            ? get_permalink( $translated_contact_page_id )
+            : '';
+
+        wp_localize_script(
+            'costa-rica-adventures-scripts',
+            'contactRedirectData',
+            [
+                'redirectUrl' => $redirect_url,
+            ]
+        );
     }
-
-    // Localize configuration for Tours Cart integration
-    wp_localize_script(
-        'costa-rica-adventures-scripts',
-        'ToursCartCfg',
-        [
-            'storageKey'    => 'toursCart',
-            'editToursURL'  => $inquiry_page_id ? get_permalink( $inquiry_page_id ) : '',
-            'isInquiryPage' => (bool) ( $inquiry_page_id && is_page( $inquiry_page_id ) ),
-        ]
-    );
-
-    // Provide a dynamic, language-aware URL for the CF7 redirect script.
-    $contact_page = get_page_by_path( 'contact-us-at' );
-    wp_localize_script(
-        'costa-rica-adventures-scripts',
-        'contactRedirectData',
-        [
-            'redirectUrl' => $contact_page ? get_permalink( $contact_page->ID ) : '',
-        ]
-    );
 }
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\register_scripts' );

--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Register Scripts and Styles
- * 
  * @package costaricaadventurers
  */
 
@@ -55,6 +54,16 @@ function register_scripts() {
             'storageKey'    => 'toursCart',
             'editToursURL'  => $inquiry_page_id ? get_permalink( $inquiry_page_id ) : '',
             'isInquiryPage' => (bool) ( $inquiry_page_id && is_page( $inquiry_page_id ) ),
+        ]
+    );
+
+    // Provide a dynamic, language-aware URL for the CF7 redirect script.
+    $contact_page = get_page_by_path( 'contact-us-at' );
+    wp_localize_script(
+        'costa-rica-adventures-scripts',
+        'contactRedirectData',
+        [
+            'redirectUrl' => $contact_page ? get_permalink( $contact_page->ID ) : '',
         ]
     );
 }

--- a/src/css/home.css
+++ b/src/css/home.css
@@ -48,3 +48,7 @@ body:is(.home) {
     }
   }
 }
+
+body.home .wpcf7 form.sent .wpcf7-response-output {
+  display: none !important;
+}

--- a/src/js/contact-form/cf7-form-connect.js
+++ b/src/js/contact-form/cf7-form-connect.js
@@ -3,15 +3,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const formElement = event.target;
     const container = formElement.closest(".wpcf7");
 
-    // Only proceed if this form has the 'js-redirect-form' class
+    // Only proceed if the form is designated for redirection.
     if (!container || !container.classList.contains("js-redirect-form")) {
-      return;
-    }
-
-    // Optional: check that event detail matches container form ID (extra safety)
-    const expectedFormID = Number(container.getAttribute("data-wpcf7-id"));
-    const formID = event.detail ? Number(event.detail.contactFormId) : 0;
-    if (formID !== expectedFormID || formID === 0) {
       return;
     }
 
@@ -22,11 +15,16 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const params = new URLSearchParams({
       client_name: nombre,
-      correo: correo,
-      telefono: telefono,
-      idioma: idioma,
+      correo,
+      telefono,
+      idioma,
     });
 
-    window.location.href = "/contact/?" + params.toString();
+    // Safely redirect using the dynamic URL provided from PHP.
+    if (typeof contactRedirectData?.redirectUrl === 'string' && contactRedirectData.redirectUrl) {
+      window.location.href = contactRedirectData.redirectUrl + "?" + params.toString();
+    } else {
+      console.error("CF7 redirect failed: Redirect URL is missing.");
+    }
   });
 });

--- a/src/js/contact-form/cf7-form-connect.js
+++ b/src/js/contact-form/cf7-form-connect.js
@@ -1,45 +1,32 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const selector = ".wpcf7";
-  const container = document.querySelector(selector);
+  document.addEventListener("wpcf7mailsent", (event) => {
+    const formElement = event.target;
+    const container = formElement.closest(".wpcf7");
 
-  if (container) {
-    document.addEventListener(
-      "wpcf7mailsent",
-      (event) => {
-        // Get the closest container that holds the data attribute (e.g. <div class="wpcf7 ...">)
-        const container = event.target.closest(".wpcf7");
-        const expectedFormID = container
-          ? Number(container.getAttribute("data-wpcf7-id"))
-          : 0;
+    // Only proceed if this form has the 'js-redirect-form' class
+    if (!container || !container.classList.contains("js-redirect-form")) {
+      return;
+    }
 
-        // Get the form ID from the event details
-        const formID = Number(event.detail.contactFormId);
+    // Optional: check that event detail matches container form ID (extra safety)
+    const expectedFormID = Number(container.getAttribute("data-wpcf7-id"));
+    const formID = event.detail ? Number(event.detail.contactFormId) : 0;
+    if (formID !== expectedFormID || formID === 0) {
+      return;
+    }
 
-        // Check if the form ID matches the expected value
-        if (formID === expectedFormID && formID !== 0) {
-          const formElement = event.target;
-          const nombreEl = formElement.querySelector('input[name="cr-name"]');
-          const correoEl = formElement.querySelector('input[name="cr-email"]');
-          const telefonoEl = formElement.querySelector(
-            'input[name="cr-phone"]'
-          );
-          const idiomaEl = formElement.querySelector('select[name="cr-language"]');
+    const nombre = formElement.querySelector('input[name="cr-name"]')?.value || "";
+    const correo = formElement.querySelector('input[name="cr-email"]')?.value || "";
+    const telefono = formElement.querySelector('input[name="cr-phone"]')?.value || "";
+    const idioma = formElement.querySelector('select[name="cr-language"]')?.value || "";
 
-          const nombre = nombreEl ? nombreEl.value : "";
-          const correo = correoEl ? correoEl.value : "";
-          const telefono = telefonoEl ? telefonoEl.value : "";
-          const idioma = idiomaEl ? idiomaEl.value : "";
+    const params = new URLSearchParams({
+      client_name: nombre,
+      correo: correo,
+      telefono: telefono,
+      idioma: idioma,
+    });
 
-          const params = new URLSearchParams();
-          params.set("client_name", nombre);
-          params.set("correo", correo);
-          params.set("telefono", telefono);
-          params.set("idioma", idioma);
-
-          window.location.href = "/contact/?" + params.toString();
-        }
-      },
-      false
-    );
-  }
+    window.location.href = "/contact/?" + params.toString();
+  });
 });

--- a/src/js/contact-form/cf7-form-connect.js
+++ b/src/js/contact-form/cf7-form-connect.js
@@ -1,11 +1,16 @@
 document.addEventListener("DOMContentLoaded", () => {
+  // Remove console logs for production, but keep error logs for debugging
   document.addEventListener("wpcf7mailsent", (event) => {
     const formElement = event.target;
-    const container = formElement.closest(".wpcf7");
 
-    // Only proceed if the form is designated for redirection.
-    if (!container || !container.classList.contains("js-redirect-form")) {
+    if (!formElement || typeof formElement.classList?.contains !== "function") {
+      console.error("❌ CF7 redirect failed: formElement is invalid.");
       return;
+    }
+
+    // Check if form contains the redirect class (inside the form)
+    if (!formElement.querySelector(".js-redirect-form")) {
+      return; // No redirect needed
     }
 
     const nombre = formElement.querySelector('input[name="cr-name"]')?.value || "";
@@ -20,8 +25,7 @@ document.addEventListener("DOMContentLoaded", () => {
       idioma,
     });
 
-    // Safely redirect using the dynamic URL provided from PHP.
-    if (typeof contactRedirectData?.redirectUrl === 'string' && contactRedirectData.redirectUrl) {
+    if (typeof contactRedirectData?.redirectUrl === "string" && contactRedirectData.redirectUrl) {
       window.location.href = contactRedirectData.redirectUrl + "?" + params.toString();
     } else {
       console.error("CF7 redirect failed: Redirect URL is missing.");


### PR DESCRIPTION
Description
This pull request addresses an issue where a Contact Form 7 redirect was using a hardcoded URL, causing it to fail in a multilingual environment. The form would always redirect to the English version of the destination page, regardless of the user's current language.

This solution refactors the implementation to follow WordPress best practices by making the redirect URL dynamic and language-aware.

Changes
inc/scripts.php:

Modified the register_scripts function to get the "Contact Us" page object by its slug (contact-us-at).

Uses get_permalink() to retrieve the correct, language-specific URL for that page.

Passes this dynamic URL to the front-end via wp_localize_script, making it available under the contactRedirectData JavaScript object.

src/js/contact-form/cf7-form-connect.js:

The script now reads the destination URL from contactRedirectData.redirectUrl instead of a hardcoded string.

This allows the same script to correctly redirect users to the appropriate language version of the contact page (e.g., /contact-us-at/, /es/contactenos/, etc.).

Includes a safety check to prevent errors if the redirect URL is not available.